### PR TITLE
bump go-kamailio-binrpc to v3.3.0

### DIFF
--- a/collector_test.go
+++ b/collector_test.go
@@ -518,8 +518,7 @@ type kv struct {
 
 // encodeStructPayload encodes key/value pairs as a single BINRPC struct
 // record, as Kamailio would return it. Values must be int, float64,
-// or string. Values are encoded by hand because binrpc.Record.Encode
-// truncates values larger than 32 bits (the read path handles them fine).
+// or string.
 func encodeStructPayload(t *testing.T, items []kv) []byte {
 	t.Helper()
 
@@ -532,16 +531,26 @@ func encodeStructPayload(t *testing.T, items []kv) []byte {
 		// with type 5 (AVP) instead of 1 (string)
 		encodeRawRecord(&buf, 0x05, append([]byte(item.key), 0x00))
 
+		var record *binrpc.Record
+		var err error
+
 		switch v := item.value.(type) {
 		case int:
-			encodeRawRecord(&buf, 0x00, minBigEndian(v))
+			record, err = binrpc.CreateRecord(v)
 		case float64:
-			// doubles are fixed-point with 3 decimals
-			encodeRawRecord(&buf, 0x02, minBigEndian(int(v*1000)))
+			record, err = binrpc.CreateRecord(v)
 		case string:
-			encodeRawRecord(&buf, 0x01, append([]byte(v), 0x00))
+			record, err = binrpc.CreateRecord(v)
 		default:
 			t.Fatalf("unsupported value type %T", item.value)
+		}
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err = record.Encode(&buf); err != nil {
+			t.Fatal(err)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
-	github.com/florentchauveau/go-kamailio-binrpc/v3 v3.2.0
+	github.com/florentchauveau/go-kamailio-binrpc/v3 v3.3.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.69.0
 	github.com/prometheus/exporter-toolkit v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/florentchauveau/go-kamailio-binrpc/v3 v3.2.0 h1:0IR+Ck/QKC9aIarfNVQdKzDZwF7OP8ekFM8M7ZHb6UY=
-github.com/florentchauveau/go-kamailio-binrpc/v3 v3.2.0/go.mod h1:6g5QZzU9yUJao66NQsR2G7Jbo5MU2s/GZWRbqx6lgNc=
+github.com/florentchauveau/go-kamailio-binrpc/v3 v3.3.0 h1:lLNjnaRGmQxIabB6C03ky3qEBowfQ532+gleSq0tVKw=
+github.com/florentchauveau/go-kamailio-binrpc/v3 v3.3.0/go.mod h1:Fh67wn8/kr3V5rvszfYFts6QehxyAZIbOUkW2HSPZ0o=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=


### PR DESCRIPTION
Brings the [v3.3.0 fixes](https://github.com/florentchauveau/go-kamailio-binrpc/releases/tag/v3.3.0): >32-bit value encoding and short-read handling.

The test harness now encodes struct values with the library's own `Encode` — the shmmem and DMQ integration tests exercise it with values larger than 32 bits, so they double as a regression guard for the library as consumed by the exporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)