### PR TITLE
add custom statistics export via stats.fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Kamailio Exporter for Prometheus
+
 [![Go Report Card](https://goreportcard.com/badge/github.com/florentchauveau/kamailio_exporter)](https://goreportcard.com/report/github.com/florentchauveau/kamailio_exporter)
 ![CI](https://github.com/florentchauveau/kamailio_exporter/actions/workflows/ci.yml/badge.svg)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/florentchauveau/kamailio_exporter/blob/master/LICENSE)
@@ -8,7 +9,7 @@ A [Kamailio](https://www.kamailio.org/) exporter for Prometheus.
 
 Safe to use in production. It has been used in production for years at [Callr](https://www.callr.com).
 
-It communicates with Kamailio using native [BINRPC](http://kamailio.org/docs/modules/stable/modules/ctl.html) via the `ctl` module. 
+It communicates with Kamailio using native [BINRPC](http://kamailio.org/docs/modules/stable/modules/ctl.html) via the `ctl` module.
 
 BINRPC is implemented in library https://github.com/florentchauveau/go-kamailio-binrpc.
 
@@ -19,11 +20,13 @@ Pre-built binaries are available in [releases](https://github.com/florentchauvea
 Docker images are also available on [DockerHub](https://hub.docker.com/r/florentchauveau/kamailio_exporter).
 
 To run it:
+
 ```bash
 ./kamailio_exporter [flags]
 ```
 
 Help on flags:
+
 ```
 ./kamailio_exporter --help
 
@@ -39,7 +42,7 @@ Flags:
   -m, --kamailio.methods="tm.stats,sl.stats,core.shmmem,core.uptime,core.tcp_info"
                                  Comma-separated list of methods to call.
                                  E.g. "tm.stats,sl.stats". Implemented:
-                                 tm.stats,sl.stats,core.shmmem,core.uptime,core.tcp_info,dispatcher.list,tls.info,dlg.stats_active
+                                 tm.stats,sl.stats,core.shmmem,core.uptime,core.tcp_info,dispatcher.list,tls.info,dlg.stats_active,dmq.list_nodes,stats.fetch
   -t, --kamailio.timeout=5s      Timeout for trying to get stats from kamailio.
       --kamailio.stats-groups="script"
                                  Comma-separated list of statistics groups to
@@ -107,6 +110,7 @@ By default (if no parameters are changed in the config file), the `ctl` module e
 ## Metrics
 
 ### Default metrics
+
 By default, the exporter will try to fetch values from the following commands:
 
 - `tm.stats` (requires the [TM](http://kamailio.org/docs/modules/stable/modules/tm.html) module)
@@ -115,16 +119,21 @@ By default, the exporter will try to fetch values from the following commands:
 - `core.uptime`
 
 ### Module specific metrics
+
 #### Dispatcher
+
 If you are using the [DISPATCHER](http://kamailio.org/docs/modules/stable/modules/dispatcher.html) module, you can enable `dispatcher.list`.
 
 #### TLS
-For [TLS]( https://kamailio.org/docs/modules/stable/modules/tls.html ) you can enable `tls.info`.
+
+For [TLS](https://kamailio.org/docs/modules/stable/modules/tls.html) you can enable `tls.info`.
 
 #### Dialog
+
 For [DIALOG](http://kamailio.org/docs/modules/stable/modules/dialog.html) module, you can enable `dlg.stats_active`.
 
 #### DMQ
+
 If you are using the [DMQ](https://kamailio.org/docs/modules/stable/modules/dmq.html) module, you can enable `dmq.list_nodes` to export the status of DMQ nodes:
 
 ```
@@ -157,6 +166,7 @@ The groups to fetch are controlled with `--kamailio.stats-groups` (default
 as well as `all`, and full statistic names (e.g. `script:destination_down`).
 
 ### Example for using non-default metrics
+
 ```bash
 ./kamailio_exporter -m "tm.stats,sl.stats,core.shmmem,core.uptime,dispatcher.list,tls.info,dlg.stats_active"
 ```
@@ -246,7 +256,7 @@ List of exposed metrics:
 
 ## Compiling
 
-With go1.25+, clone the project and:
+With go1.26+, clone the project and:
 
 ```bash
 go build

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Flags:
                                  E.g. "tm.stats,sl.stats". Implemented:
                                  tm.stats,sl.stats,core.shmmem,core.uptime,core.tcp_info,dispatcher.list,tls.info,dlg.stats_active
   -t, --kamailio.timeout=5s      Timeout for trying to get stats from kamailio.
+      --kamailio.stats-groups="script"
+                                 Comma-separated list of statistics groups to
+                                 export with the "stats.fetch" method. E.g.
+                                 "script,core". Only used if "stats.fetch" is
+                                 present in --kamailio.methods.
       --[no-]web.systemd-socket  Use systemd socket activation listeners instead
                                  of port listeners (Linux only).
       --web.listen-address=:9494 ...
@@ -125,6 +130,31 @@ If you are using the [DMQ](https://kamailio.org/docs/modules/stable/modules/dmq.
 ```
 kamailio_dmq_list_nodes_node{host="10.0.0.2",local="0",port="5090",status="active"} 1
 ```
+
+### Custom statistics (script stats)
+
+Statistics created in your Kamailio config with `update_stat()` live in the
+`script` group of the statistics framework:
+
+```
+event_route[dispatcher:dst-down] {
+    update_stat("destination_down", "+1");
+}
+```
+
+Enable the `stats.fetch` method to export them:
+
+```bash
+./kamailio_exporter -m "tm.stats,sl.stats,core.shmmem,core.uptime,stats.fetch"
+```
+
+```
+kamailio_stats_fetch_value{group="script",name="destination_down"} 4
+```
+
+The groups to fetch are controlled with `--kamailio.stats-groups` (default
+`script`). Any group of the statistics framework works (e.g. `script,core`),
+as well as `all`, and full statistic names (e.g. `script:destination_down`).
 
 ### Example for using non-default metrics
 ```bash

--- a/collector.go
+++ b/collector.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -93,10 +94,11 @@ type Collector struct {
 	Timeout time.Duration
 	Methods []string
 
-	scheme  string
-	address string
-	mutex   sync.Mutex
-	logger  *slog.Logger
+	scheme      string
+	address     string
+	statsGroups []string
+	mutex       sync.Mutex
+	logger      *slog.Logger
 
 	up            prometheus.Gauge
 	failedScrapes prometheus.Counter
@@ -152,6 +154,7 @@ var (
 		"tls.info",
 		"dlg.stats_active",
 		"dmq.list_nodes",
+		"stats.fetch",
 	}
 
 	metricsList = map[string][]Metric{
@@ -207,6 +210,9 @@ var (
 		"dmq.list_nodes": {
 			NewMetricGauge("node", "DMQ node status.", "dmq.list_nodes"),
 		},
+		"stats.fetch": {
+			NewMetricGauge("value", "Statistic value.", "stats.fetch"),
+		},
 	}
 )
 
@@ -230,8 +236,8 @@ func NewMetricCounter(name string, help string, method string) Metric {
 	}
 }
 
-// NewCollector processes uri, timeout and methods and returns a new Collector.
-func NewCollector(uri string, timeout time.Duration, methods string, logger *slog.Logger) (*Collector, error) {
+// NewCollector processes uri, timeout, methods and statsGroups, and returns a new Collector.
+func NewCollector(uri string, timeout time.Duration, methods string, statsGroups string, logger *slog.Logger) (*Collector, error) {
 	c := Collector{}
 
 	c.URI = uri
@@ -282,6 +288,27 @@ func NewCollector(uri string, timeout time.Duration, methods string, logger *slo
 				strings.Join(availableMethods, ","),
 			)
 		}
+	}
+
+	for _, group := range strings.Split(statsGroups, ",") {
+		group = strings.TrimSpace(group)
+
+		if group == "" {
+			continue
+		}
+
+		// the group syntax of "stats.fetch" requires a trailing
+		// colon (e.g. "script:"), except for "all" and full
+		// statistic names (e.g. "script:destination_down")
+		if group != "all" && !strings.Contains(group, ":") {
+			group += ":"
+		}
+
+		c.statsGroups = append(c.statsGroups, group)
+	}
+
+	if len(c.statsGroups) == 0 && slices.Contains(c.Methods, "stats.fetch") {
+		return nil, errors.New(`method "stats.fetch" requires at least one group in statsGroups`)
 	}
 
 	c.up = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -418,7 +445,13 @@ func (c *Collector) scrape(ch chan<- prometheus.Metric) error {
 
 // scrapeMethod will return metrics for one method.
 func (c *Collector) scrapeMethod(conn net.Conn, method string) (map[string][]MetricValue, error) {
-	records, err := fetchBINRPC(conn, method)
+	request := []string{method}
+
+	if method == "stats.fetch" {
+		request = append(request, c.statsGroups...)
+	}
+
+	records, err := fetchBINRPC(conn, request...)
 
 	if err != nil {
 		return nil, err
@@ -482,6 +515,29 @@ func (c *Collector) scrapeMethod(conn net.Conn, method string) (map[string][]Met
 			}
 
 			metrics[item.Key] = []MetricValue{{Value: value}}
+		}
+	case "stats.fetch":
+		// keys are "group.name", e.g. "script.destination_down"
+		for _, item := range items {
+			value, err := c.scanValue(method, item)
+
+			if err != nil {
+				continue
+			}
+
+			group, name, found := strings.Cut(item.Key, ".")
+
+			if !found {
+				group, name = "", item.Key
+			}
+
+			metrics["value"] = append(metrics["value"], MetricValue{
+				Value: value,
+				Labels: map[string]string{
+					"group": group,
+					"name":  name,
+				},
+			})
 		}
 	case "dispatcher.list":
 		targets, err := parseDispatcherTargets(items)
@@ -659,9 +715,10 @@ func parseDispatcherTargets(items []binrpc.StructItem) ([]DispatcherTarget, erro
 }
 
 // fetchBINRPC talks to kamailio using the BINRPC protocol.
-func fetchBINRPC(conn net.Conn, method string) ([]binrpc.Record, error) {
+// The request is a method name, optionally followed by its arguments.
+func fetchBINRPC(conn net.Conn, request ...string) ([]binrpc.Record, error) {
 	// WritePacket returns the cookie generated
-	cookie, err := binrpc.WritePacket(conn, method)
+	cookie, err := binrpc.WritePacket(conn, request...)
 
 	if err != nil {
 		return nil, err

--- a/collector_test.go
+++ b/collector_test.go
@@ -75,7 +75,7 @@ func TestMetricValueLabels(t *testing.T) {
 }
 
 func TestNewCollector(t *testing.T) {
-	c, err := NewCollector("tcp://localhost:2049", time.Second, "tm.stats,sl.stats", promslog.NewNopLogger())
+	c, err := NewCollector("tcp://localhost:2049", time.Second, "tm.stats,sl.stats", "script", promslog.NewNopLogger())
 
 	if err != nil {
 		t.Fatal(err)
@@ -85,8 +85,25 @@ func TestNewCollector(t *testing.T) {
 		t.Errorf("unexpected methods: %v", c.Methods)
 	}
 
-	if _, err = NewCollector("tcp://localhost:2049", time.Second, "invalid.method", promslog.NewNopLogger()); err == nil {
+	if _, err = NewCollector("tcp://localhost:2049", time.Second, "invalid.method", "script", promslog.NewNopLogger()); err == nil {
 		t.Error("expected an error for an invalid method")
+	}
+
+	// group names are normalized with a trailing colon, except "all"
+	// and full statistic names
+	c, err = NewCollector("tcp://localhost:2049", time.Second, "stats.fetch", "script, core,all,script:custom", promslog.NewNopLogger())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(c.statsGroups, []string{"script:", "core:", "all", "script:custom"}) {
+		t.Errorf("unexpected stats groups: %v", c.statsGroups)
+	}
+
+	// "stats.fetch" requires at least one group
+	if _, err = NewCollector("tcp://localhost:2049", time.Second, "stats.fetch", "", promslog.NewNopLogger()); err == nil {
+		t.Error(`expected an error for "stats.fetch" without groups`)
 	}
 }
 
@@ -109,7 +126,7 @@ func TestNewCollectorURI(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c, err := NewCollector(test.uri, time.Second, "tm.stats", promslog.NewNopLogger())
+		c, err := NewCollector(test.uri, time.Second, "tm.stats", "script", promslog.NewNopLogger())
 
 		if test.invalid {
 			if err == nil {
@@ -197,7 +214,7 @@ func TestCollectorScrapeTCP(t *testing.T) {
 		"tm.stats": payload,
 	})
 
-	c, err := NewCollector("tcp://"+address, time.Second, "tm.stats", promslog.NewNopLogger())
+	c, err := NewCollector("tcp://"+address, time.Second, "tm.stats", "script", promslog.NewNopLogger())
 
 	if err != nil {
 		t.Fatal(err)
@@ -234,7 +251,7 @@ func TestCollectorScrapeTCP(t *testing.T) {
 	}
 
 	// the "opaque" URI form (without slashes) must work too (#28)
-	opaque, err := NewCollector("tcp:"+address, time.Second, "tm.stats", promslog.NewNopLogger())
+	opaque, err := NewCollector("tcp:"+address, time.Second, "tm.stats", "script", promslog.NewNopLogger())
 
 	if err != nil {
 		t.Fatal(err)
@@ -251,7 +268,7 @@ func TestCollectorScrapeUnixSocket(t *testing.T) {
 		"tm.stats": payload,
 	})
 
-	c, err := NewCollector("unix:"+socket, time.Second, "tm.stats", promslog.NewNopLogger())
+	c, err := NewCollector("unix:"+socket, time.Second, "tm.stats", "script", promslog.NewNopLogger())
 
 	if err != nil {
 		t.Fatal(err)
@@ -284,7 +301,7 @@ func TestCollectorScrapeShmmemDoubles(t *testing.T) {
 		"core.shmmem": payload,
 	})
 
-	c, err := NewCollector("tcp://"+address, time.Second, "core.shmmem", promslog.NewNopLogger())
+	c, err := NewCollector("tcp://"+address, time.Second, "core.shmmem", "script", promslog.NewNopLogger())
 
 	if err != nil {
 		t.Fatal(err)
@@ -357,7 +374,7 @@ func TestCollectorScrapeDMQNodes(t *testing.T) {
 		"dmq.list_nodes": slices.Concat(node1, node2),
 	})
 
-	c, err := NewCollector("tcp://"+address, time.Second, "dmq.list_nodes", promslog.NewNopLogger())
+	c, err := NewCollector("tcp://"+address, time.Second, "dmq.list_nodes", "script", promslog.NewNopLogger())
 
 	if err != nil {
 		t.Fatal(err)
@@ -375,6 +392,44 @@ func TestCollectorScrapeDMQNodes(t *testing.T) {
 
 	err = testutil.CollectAndCompare(c, strings.NewReader(expected),
 		"kamailio_dmq_list_nodes_node",
+		"kamailio_up",
+	)
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestCollectorScrapeStatsFetch(t *testing.T) {
+	// "stats.fetch" takes group arguments and returns a struct with
+	// "group.name" keys and string values
+	payload := encodeStructPayload(t, []kv{
+		{"script.destination_down", "4"},
+		{"script.destination_up", "2"},
+	})
+
+	address := startFakeKamailio(t, "tcp", "127.0.0.1:0", map[string][]byte{
+		"stats.fetch script:": payload,
+	})
+
+	c, err := NewCollector("tcp://"+address, time.Second, "stats.fetch", "script", promslog.NewNopLogger())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `
+		# HELP kamailio_stats_fetch_value Statistic value.
+		# TYPE kamailio_stats_fetch_value gauge
+		kamailio_stats_fetch_value{group="script",name="destination_down"} 4
+		kamailio_stats_fetch_value{group="script",name="destination_up"} 2
+		# HELP kamailio_up Was the last scrape successful.
+		# TYPE kamailio_up gauge
+		kamailio_up 1
+	`
+
+	err = testutil.CollectAndCompare(c, strings.NewReader(expected),
+		"kamailio_stats_fetch_value",
 		"kamailio_up",
 	)
 
@@ -401,7 +456,7 @@ func TestCollectorScrapeErrorResponse(t *testing.T) {
 		"tm.stats": payload.Bytes(),
 	})
 
-	c, err := NewCollector("tcp://"+address, time.Second, "tm.stats", promslog.NewNopLogger())
+	c, err := NewCollector("tcp://"+address, time.Second, "tm.stats", "script", promslog.NewNopLogger())
 
 	if err != nil {
 		t.Fatal(err)
@@ -421,7 +476,7 @@ func TestCollectorScrapeConnectionRefused(t *testing.T) {
 	address := listener.Addr().String()
 	listener.Close()
 
-	c, err := NewCollector("tcp://"+address, time.Second, "tm.stats", promslog.NewNopLogger())
+	c, err := NewCollector("tcp://"+address, time.Second, "tm.stats", "script", promslog.NewNopLogger())
 
 	if err != nil {
 		t.Fatal(err)
@@ -474,8 +529,10 @@ func startFakeKamailio(t *testing.T, network string, address string, payloads ma
 	return listener.Addr().String()
 }
 
-// serveBINRPC answers BINRPC requests on conn until an error occurs
-// or an unknown method is requested.
+// serveBINRPC answers BINRPC requests on conn until an error occurs or
+// an unknown request is received. Responses are keyed by the full
+// request: the method name followed by its arguments, joined with
+// spaces (e.g. "tm.stats" or "stats.fetch script:").
 func serveBINRPC(conn net.Conn, payloads map[string][]byte) {
 	defer conn.Close()
 
@@ -486,25 +543,40 @@ func serveBINRPC(conn net.Conn, payloads map[string][]byte) {
 			return
 		}
 
-		record, err := binrpc.ReadRecord(conn)
+		payload := make([]byte, header.PayloadLength)
 
-		if err != nil {
+		if _, err = io.ReadFull(conn, payload); err != nil {
 			return
 		}
 
-		method, err := record.String()
+		// the request is one string record for the method name,
+		// followed by string records for its arguments
+		var request []string
+		reader := bytes.NewReader(payload)
 
-		if err != nil {
-			return
+		for reader.Len() > 0 {
+			record, err := binrpc.ReadRecord(reader)
+
+			if err != nil {
+				return
+			}
+
+			s, err := record.String()
+
+			if err != nil {
+				return
+			}
+
+			request = append(request, s)
 		}
 
-		payload, found := payloads[method]
+		response, found := payloads[strings.Join(request, " ")]
 
 		if !found {
 			return
 		}
 
-		if err = writeRawPacket(conn, header.Cookie, payload); err != nil {
+		if err = writeRawPacket(conn, header.Cookie, response); err != nil {
 			return
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ func main() {
 		scrapeURI    = kingpin.Flag("kamailio.scrape-uri", `URI on which to scrape kamailio. E.g. "unix:/var/run/kamailio/kamailio_ctl" or "tcp://localhost:2049"`).Short('u').Default("unix:/var/run/kamailio/kamailio_ctl").String()
 		methods      = kingpin.Flag("kamailio.methods", `Comma-separated list of methods to call. E.g. "tm.stats,sl.stats". Implemented: `+strings.Join(availableMethods, ",")).Short('m').Default("tm.stats,sl.stats,core.shmmem,core.uptime,core.tcp_info").String()
 		timeout      = kingpin.Flag("kamailio.timeout", "Timeout for trying to get stats from kamailio.").Short('t').Default("5s").Duration()
+		statsGroups  = kingpin.Flag("kamailio.stats-groups", `Comma-separated list of statistics groups to export with the "stats.fetch" method. E.g. "script,core". Only used if "stats.fetch" is present in --kamailio.methods.`).Default("script").String()
 		toolkitFlags = kingpinflag.AddFlags(kingpin.CommandLine, ":9494")
 	)
 
@@ -34,7 +35,7 @@ func main() {
 
 	logger := promslog.New(promslogConfig)
 
-	c, err := NewCollector(*scrapeURI, *timeout, *methods, logger)
+	c, err := NewCollector(*scrapeURI, *timeout, *methods, *statsGroups, logger)
 
 	if err != nil {
 		logger.Error("cannot create collector", "error", err)


### PR DESCRIPTION
Fixes #21.

New opt-in method `stats.fetch` exports statistics from the Kamailio statistics framework, including custom script stats created with `update_stat()`:

```
./kamailio_exporter -m "tm.stats,sl.stats,core.shmmem,core.uptime,stats.fetch"
```
```
kamailio_stats_fetch_value{group="script",name="destination_down"} 4
```

- Groups are controlled with `--kamailio.stats-groups` (default `script`); accepts group names (`script,core`), `all`, or full statistic names (`script:destination_down`). Trailing colons are added automatically for group names.
- Labels rather than dynamic metric names, since custom stat names are user-defined and could contain characters invalid in Prometheus metric names. Gauge semantics, because script stats can be decremented.
- First method that passes RPC arguments over BINRPC; `fetchBINRPC` is now variadic and the fake test server parses full requests (method + args).
- Values arrive string-encoded from `stats.fetch` (verified against Kamailio's `kex/core_stats.c`); the collector's `Scan`-based parsing handles that transparently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)