### PR TITLE
skip non-metric struct fields, add agent notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# kamailio_exporter — agent notes
+
+Prometheus exporter for Kamailio, scraping over the ctl module's BINRPC
+socket (via github.com/florentchauveau/go-kamailio-binrpc).
+
+Single `package main`: `main.go` (flags, exporter-toolkit listener),
+`collector.go` (prometheus.Collector), `collector_test.go`. Module path
+is `/v2`.
+
+## Logging
+
+Logging goes through `github.com/prometheus/common/promslog` (Prometheus
+exporter toolkit, logfmt output) — never import `log/slog` directly, even
+in tests. `promslog.New()` returns a `*slog.Logger`, so fields typed
+`*slog.Logger` are fine; only the construction must use promslog.
+
+- Production: `promslog.New(&promslog.Config{})` (see main.go)
+- Tests, discarded output: `promslog.NewNopLogger()`
+- Tests, captured output: `promslog.New(&promslog.Config{Writer: &buf})`
+
+## Collector conventions
+
+- RPC methods are whitelisted in `availableMethods` and declared in
+  `metricsList`; per-method response parsing lives in the switch in
+  `scrapeMethod`. Metric names are `kamailio_<method>_<name>` (dots
+  become underscores), counters get a `_total` suffix (`ExportedName`).
+- Parse numeric values with `scanValue`/`Record.Scan` into float64 —
+  never `Int()` directly. Kamailio returns ints, doubles, or strings
+  depending on version (issue #30: shmmem doubles used to export as 0).
+  Log and skip unparseable values; never export 0 for them.
+- Dynamic names (custom stats, node addresses) go into labels, not
+  metric names — user-defined strings may be invalid Prometheus
+  identifiers, and duplicate label sets fail the whole scrape (include
+  enough labels, e.g. dmq nodes need `port`).
+- Response shapes: most methods return one struct record;
+  `dmq.list_nodes` returns one record per node; `stats.fetch` takes RPC
+  arguments (groups need a trailing colon, e.g. `script:`) and returns
+  `group.name` keys (dot-separated). A `[500, message]` pair is an
+  error response, handled before method parsing.
+- `fetchBINRPC` is variadic: method first, then RPC arguments.
+
+## Tests
+
+- `go test -race ./...`; CI also enforces `go vet` and `gofmt -l`.
+- Integration tests run against a fake BINRPC server
+  (`startFakeKamailio`): responses are keyed by the full request —
+  method and arguments joined with spaces (`"stats.fetch script:"`).
+- Build struct responses with `encodeStructPayload` (int, float64,
+  string values); concatenate payloads for multi-record responses.
+  `tmStatsPayload` is a real captured response.
+- When fixing a bug, prove the new test fails on the old code
+  (`git stash push <file>` → test → `git stash pop`).
+
+## Release flow
+
+- Florent creates releases manually in the GitHub UI (pre-release box
+  for rc tags). The release workflow triggers on `release: published`;
+  goreleaser attaches binaries to the existing release and preserves
+  its notes (keep-existing) and pre-release flag (`prerelease: auto`).
+- Never switch the trigger back to tag push: it races with UI-created
+  releases (two release writers → 422 tag already_exists).
+- Versions are stamped into `github.com/prometheus/common/version` via
+  ldflags in `.goreleaser.yaml` (there is no `main.version`). Verify a
+  released binary with `--version` and `go version -m` (dep versions).
+- Docker images are built by a separate buildx job in the same
+  workflow (not by goreleaser).
+
+## Git conventions
+
+- No direct pushes to master: branch + PR, and Florent merges. Use
+  merge commits (not squash) — commit SHAs get referenced in issue/PR
+  replies, and goreleaser builds release changelogs from commits.
+- Commit style: lowercase summaries, `ci:`/`docs:`/`chore(deps):`
+  prefixes for non-feature changes.
+
+## Sibling library
+
+`go-kamailio-binrpc` lives at `~/code/go-kamailio-binrpc` (same
+conventions). It is a zero-dependency library: keep its `go` directive
+as low as possible (it is a floor forced on all importers). The BINRPC
+wire format is documented by its tests; watch for int size limits —
+values are variable-length big-endian, doubles are fixed-point ×1000.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/collector.go
+++ b/collector.go
@@ -508,6 +508,12 @@ func (c *Collector) scrapeMethod(conn net.Conn, method string) (map[string][]Met
 		}
 	case "tls.info", "core.shmmem", "core.tcp_info", "dlg.stats_active", "core.uptime":
 		for _, item := range items {
+			// skip fields that are not exported metrics, such as the
+			// "now" and "up_since" date strings of "core.uptime"
+			if !isDefinedMetric(method, item.Key) {
+				continue
+			}
+
 			value, err := c.scanValue(method, item)
 
 			if err != nil {
@@ -626,6 +632,17 @@ func (c *Collector) scanValue(method string, item binrpc.StructItem) (float64, e
 	}
 
 	return value, nil
+}
+
+// isDefinedMetric reports whether key is a defined metric of method.
+func isDefinedMetric(method string, key string) bool {
+	for _, metric := range metricsList[method] {
+		if metric.Name == key {
+			return true
+		}
+	}
+
+	return false
 }
 
 // parseDispatcherTargets parses the "dispatcher.list" result and returns a list of targets.

--- a/collector_test.go
+++ b/collector_test.go
@@ -346,6 +346,55 @@ func TestCollectorScrapeShmmemDoubles(t *testing.T) {
 	}
 }
 
+func TestCollectorScrapeUptime(t *testing.T) {
+	// "core.uptime" also returns "now" and "up_since" as date strings;
+	// they are not exported and must not trigger parse error logs.
+	// The reply shape is identical from Kamailio 4.4 through master
+	// (core_cmd.c core_uptime): "now"/"up_since" strings (4.x keeps
+	// ctime's trailing newline, "now" is absent if ctime_r fails) and
+	// "uptime" always an int
+	payload := encodeStructPayload(t, []kv{
+		{"now", "Wed Jul  8 09:37:43 2026"},
+		{"up_since", "Wed Jul  8 09:37:36 2026"},
+		{"uptime", 7},
+	})
+
+	address := startFakeKamailio(t, "tcp", "127.0.0.1:0", map[string][]byte{
+		"core.uptime": payload,
+	})
+
+	var logs bytes.Buffer
+	logger := promslog.New(&promslog.Config{Writer: &logs})
+
+	c, err := NewCollector("tcp://"+address, time.Second, "core.uptime", "script", logger)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `
+		# HELP kamailio_core_uptime_uptime_total Uptime in seconds.
+		# TYPE kamailio_core_uptime_uptime_total counter
+		kamailio_core_uptime_uptime_total 7
+		# HELP kamailio_up Was the last scrape successful.
+		# TYPE kamailio_up gauge
+		kamailio_up 1
+	`
+
+	err = testutil.CollectAndCompare(c, strings.NewReader(expected),
+		"kamailio_core_uptime_uptime_total",
+		"kamailio_up",
+	)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if strings.Contains(logs.String(), "cannot parse value") {
+		t.Errorf("unexpected parse error logged: %s", logs.String())
+	}
+}
+
 func TestCollectorScrapeDMQNodes(t *testing.T) {
 	// "dmq.list_nodes" returns one struct record per node
 	node1 := encodeStructPayload(t, []kv{


### PR DESCRIPTION
Two commits:

- **skip struct fields that are not defined metrics**: `core.uptime` also returns `now` and `up_since` as date strings; they are not exported and logged a parse error on every scrape. Covered by a test asserting no parse errors are logged.
- **docs: add agent notes** (`AGENTS.md`, with `CLAUDE.md` as a symlink): collector conventions, test harness usage, release flow, git conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)