### PR TITLE
ci: pin goreleaser to the release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,11 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # pin goreleaser to the tag that triggered the workflow:
+          # auto-detection picks the wrong tag when several tags point
+          # at the same commit (e.g. v2.0.0 tagged on the same commit
+          # as v2.0.0-rc4), and then uploads to the wrong release
+          GORELEASER_CURRENT_TAG: ${{ github.event.release.tag_name }}
 
   docker:
     name: Cross-platform Docker images


### PR DESCRIPTION
The v2.0.0 release run failed: v2.0.0 was tagged on the same commit as v2.0.0-rc4, goreleaser's tag auto-detection picked `v2.0.0-rc4` (`git tag --points-at HEAD` sort order), and it tried to upload the binaries to the rc4 release — 422 `already_exists` on every asset ([failed run](https://github.com/florentchauveau/kamailio_exporter/actions/runs/28943580591/job/85871593467)).

Setting `GORELEASER_CURRENT_TAG` to `github.event.release.tag_name` pins goreleaser to the tag of the release that actually triggered the workflow, so this can never happen again regardless of how tags overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)